### PR TITLE
Es-Imports for commands

### DIFF
--- a/src/commands/announce.ts
+++ b/src/commands/announce.ts
@@ -1,14 +1,10 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
-import {
-    Client,
-    CommandInteraction,
-    MessageEmbed,
-    TextChannel,
-} from "discord.js";
+import { MessageEmbed, TextChannel } from "discord.js";
 import config from "../config";
+import { IBotCommand } from "../types";
 import { askQuestion } from "../utils";
 
-module.exports = {
+export const command: IBotCommand = {
     data: new SlashCommandBuilder()
         .setName("announce")
         .setDescription("Write an announcement for the server.")
@@ -19,7 +15,7 @@ module.exports = {
                 .setRequired(true)
         ),
     requiredPerms: ["ADMINISTRATOR"],
-    async execute(interaction: CommandInteraction<"cached">, client: Client) {
+    async execute(interaction, client) {
         const announcement = await askQuestion(
             interaction,
             "Please now send the announcement message.",

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,7 +1,8 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { CommandInteraction, MessageEmbed } from "discord.js";
+import { MessageEmbed } from "discord.js";
+import { IBotCommand } from "../types";
 
-module.exports = {
+export const command: IBotCommand = {
     data: new SlashCommandBuilder()
         .setName("clear")
         .setDescription("Delete specified amount of messages.")
@@ -12,7 +13,7 @@ module.exports = {
                 .setRequired(true)
         ),
     requiredPerms: ["MANAGE_MESSAGES"],
-    async execute(interaction: CommandInteraction<"cached">) {
+    async execute(interaction) {
         const deleted = await interaction.channel!.bulkDelete(
             interaction.options.getNumber("amount", true),
             true

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -1,8 +1,9 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { CommandInteraction, GuildMember, MessageEmbed } from "discord.js";
-import execute,{ evaluate } from "mathjs";
+import { MessageEmbed } from "discord.js";
+import execute, { evaluate } from "mathjs";
+import { IBotCommand } from "../types";
 
-module.exports = {
+export const command: IBotCommand = {
     data: new SlashCommandBuilder()
         .setName("math")
         .setDescription("Calculates the input.")
@@ -12,9 +13,9 @@ module.exports = {
                 .setDescription("Calculation to evaluate.")
                 .setRequired(true)
         ),
-    async execute(interaction: CommandInteraction) {
+    async execute(interaction) {
         const calc = interaction.options.getString("calculation", true);
-        
+
         try {
             const result = evaluate(calc);
             const successEmbed = new MessageEmbed()

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,25 +1,27 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { CommandInteraction } from "discord.js";
+import { IBotCommand } from "../types";
 
 const timeout = (seconds: number): Promise<void> => {
-    return new Promise(resolve => {
-        setTimeout(() => { resolve(undefined) }, seconds * 1000);
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            resolve(undefined);
+        }, seconds * 1000);
     });
-}
+};
 
-module.exports = {
+export const command: IBotCommand = {
     data: new SlashCommandBuilder()
         .setName("ping")
         .setDescription("Replies with a pong!"),
     async execute(interaction: CommandInteraction<"cached">) {
         // This is purely for my own amusement - conaticus
-        
+
         if (Math.random() < 0.9) {
             await interaction.reply("Pong!");
             return;
         }
-        
-        
+
         await interaction.reply("Overriding systems..");
         interaction.channel?.send("Mwuhahahaha.");
         await timeout(0.5);

--- a/src/commands/quiz.ts
+++ b/src/commands/quiz.ts
@@ -1,13 +1,12 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import {
-    Client,
-    CommandInteraction,
     Message,
     MessageEmbed,
     MessageReaction,
     TextChannel,
     User,
 } from "discord.js";
+import { IBotCommand } from "../types";
 
 interface IQuestion {
     question: string;
@@ -173,7 +172,7 @@ const constructQuestions = async (
     return await constructQuestions(user, channel, questions);
 };
 
-module.exports = {
+export const command: IBotCommand = {
     data: new SlashCommandBuilder()
         .setName("quiz")
         .setDescription("Create a quiz for server members to play.")
@@ -184,7 +183,7 @@ module.exports = {
                 .setRequired(true)
         ),
     requiredPerms: ["ADMINISTRATOR"],
-    async execute(interaction: CommandInteraction<"cached">, client: Client) {
+    async execute(interaction, client) {
         const quizChannel = interaction.options.getChannel(
             "channel"
         ) as TextChannel;

--- a/src/commands/repeat.ts
+++ b/src/commands/repeat.ts
@@ -1,6 +1,8 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { CommandInteraction, MessageEmbed } from "discord.js";
-module.exports = {
+import { MessageEmbed } from "discord.js";
+import { IBotCommand } from "../types";
+
+export const command: IBotCommand = {
     data: new SlashCommandBuilder()
         .setName("repeat")
         .setDescription("Repeats a given message")
@@ -11,7 +13,7 @@ module.exports = {
                 .setRequired(true)
         ),
     requiredPerms: ["ADMINISTRATOR"],
-    async execute(interaction: CommandInteraction<"cached">) {
+    async execute(interaction) {
         interaction.channel?.send(
             interaction.options.getString("message", true)
         );

--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -6,8 +6,9 @@ import {
     TextChannel,
 } from "discord.js";
 import config from "../config";
+import { IBotCommand } from "../types";
 
-module.exports = {
+export const command: IBotCommand = {
     data: new SlashCommandBuilder()
         .setName("suggest")
         .setDescription("Write a new suggestion for the channel.")
@@ -23,7 +24,7 @@ module.exports = {
                 .setDescription("Set suggestion's description.")
                 .setRequired(true)
         ),
-    async execute(interaction: CommandInteraction<"cached">, client: Client) {
+    async execute(interaction, client) {
         const suggestionsChannel = client.channels.cache.get(
             config.suggestionsChannelId
         ) as TextChannel;

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -2,21 +2,30 @@ import { REST } from "@discordjs/rest";
 import { Routes } from "discord-api-types/v9";
 import { commandFiles } from "./files";
 import { IBotCommand } from "./types";
-import  config  from "./config"
+import config from "./config";
 
-const commands: object[] = [];
+async () => {
+    const commands: object[] = [];
 
-for (const file of commandFiles) {
-    const command = require(file) as IBotCommand;
-    commands.push(command.data.toJSON());
-}
+    for (const file of commandFiles) {
+        const command = (await import(file)).command as IBotCommand;
+        if (!command) {
+            console.error(
+                `File at path ${file} seems to incorrectly be exporting a command.`
+            );
+            continue;
+        }
 
-const rest = new REST({ version: "9" }).setToken(process.env.TOKEN!);
+        commands.push(command.data.toJSON());
+    }
 
-rest.put(
-    Routes.applicationGuildCommands(
-        process.env.CLIENT_ID!,
-        config.guildId as string
-    ),
-    { body: commands }
-);
+    const rest = new REST({ version: "9" }).setToken(process.env.TOKEN!);
+
+    rest.put(
+        Routes.applicationGuildCommands(
+            process.env.CLIENT_ID!,
+            config.guildId as string
+        ),
+        { body: commands }
+    );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,21 +7,23 @@ import { IBotClient, IBotCommand } from "./types";
 import { commandFiles, eventFiles } from "./files";
 import Logger from "./logger/Logger";
 
-const client = new Client({
-    intents: [
-        Intents.FLAGS.GUILDS,
-        Intents.FLAGS.GUILD_MESSAGES,
-        Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
-        Intents.FLAGS.GUILD_MEMBERS,
-        Intents.FLAGS.GUILD_PRESENCES,
-    ],
-    partials: ["MESSAGE", "CHANNEL", "REACTION"],
-}) as IBotClient;
-client.commands = new Collection();
+async () => {
+    const client = new Client({
+        intents: [
+            Intents.FLAGS.GUILDS,
+            Intents.FLAGS.GUILD_MESSAGES,
+            Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+            Intents.FLAGS.GUILD_MEMBERS,
+            Intents.FLAGS.GUILD_PRESENCES,
+        ],
+        partials: ["MESSAGE", "CHANNEL", "REACTION"],
+    }) as IBotClient;
+    client.commands = new Collection();
 
-let serverLogger: Logger;
-client.on("ready", async () => {
-    serverLogger = new Logger(config.logChannelId, client);
+    let serverLogger: Logger;
+    client.on("ready", async () => {
+        serverLogger = new Logger(config.logChannelId, client);
+    });
 
     for (const file of commandFiles) {
         const command = (await import(file)).command as IBotCommand;
@@ -49,6 +51,6 @@ client.on("ready", async () => {
             event.execute(...args, client, serverLogger)
         );
     }
-});
 
-client.login(process.env.TOKEN);
+    client.login(process.env.TOKEN);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,28 +20,35 @@ const client = new Client({
 client.commands = new Collection();
 
 let serverLogger: Logger;
-client.on("ready", () => {
+client.on("ready", async () => {
     serverLogger = new Logger(config.logChannelId, client);
-});
 
-for (const file of commandFiles) {
-    const command = require(file) as IBotCommand;
-    client.commands.set(command.data.name, command);
-}
+    for (const file of commandFiles) {
+        const command = (await import(file)).command as IBotCommand;
+        if (!command) {
+            console.error(
+                `File at path ${file} seems to incorrectly be exporting a command.`
+            );
+            continue;
+        }
 
-for (const file of eventFiles) {
-    const event = require(file);
-
-    if (event.once) {
-        client.once(event.name, (...args) =>
-            event.execute(...args, client, serverLogger)
-        );
-        continue;
+        client.commands.set(command.data.name, command);
     }
 
-    client.on(event.name, (...args) =>
-        event.execute(...args, client, serverLogger)
-    );
-}
+    for (const file of eventFiles) {
+        const event = require(file);
+
+        if (event.once) {
+            client.once(event.name, (...args) =>
+                event.execute(...args, client, serverLogger)
+            );
+            continue;
+        }
+
+        client.on(event.name, (...args) =>
+            event.execute(...args, client, serverLogger)
+        );
+    }
+});
 
 client.login(process.env.TOKEN);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { IBotClient, IBotCommand } from "./types";
 import { commandFiles, eventFiles } from "./files";
 import Logger from "./logger/Logger";
 
-async () => {
+(async () => {
     const client = new Client({
         intents: [
             Intents.FLAGS.GUILDS,
@@ -53,4 +53,4 @@ async () => {
     }
 
     client.login(process.env.TOKEN);
-};
+})();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,20 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { Client, Collection, PermissionResolvable } from "discord.js";
+import {
+    Client,
+    Collection,
+    CommandInteraction,
+    PermissionResolvable,
+} from "discord.js";
 
 export interface IBotCommand {
-    data: SlashCommandBuilder;
+    data:
+        | SlashCommandBuilder
+        | Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">;
     requiredPerms?: PermissionResolvable;
-    execute: Function;
+    execute: (
+        interaction: CommandInteraction<"cached">,
+        client: IBotClient
+    ) => unknown;
 }
 
 export interface IBotClient extends Client<true> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,10 +3,10 @@ import { IDataObject } from "./types";
 import fs from "fs/promises";
 
 export const getData = async (): Promise<IDataObject> =>
-    JSON.parse(await fs.readFile("../data.json", "utf8"));
+    JSON.parse(await fs.readFile("./data.json", "utf8"));
 
 export const writeData = (data: IDataObject) =>
-    fs.writeFile("../data.json", JSON.stringify(data));
+    fs.writeFile("./data.json", JSON.stringify(data));
 
 interface QuestionOptions {
     ephemeral: boolean;


### PR DESCRIPTION
This pr simply remakes commands to use es-imports.
Why? Intellisense and we don't need to type the execute method in each file any more

I didn't do it for events cuz typing those will be harder if we want to make it so you don't have to explicitly type them in each file

Also DELTA suggested a thing with command classes, if you want you can implement that on top of this it shouldn't be that hard