### PR TITLE
remove: Unneeded function

### DIFF
--- a/src/structures/Bot.ts
+++ b/src/structures/Bot.ts
@@ -27,7 +27,7 @@ export class Bot extends Client<true> {
                 continue;
             }
 
-            const listenerMethod = ["on", "off", "once"];
+            const listenerMethod = ["on", "once"];
             for await (const method of listenerMethod) {
                 // I can't find a better way to do this, I am sorry
                 // @ts-expect-error

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,6 @@ export interface IBotEvent<T extends EventName> {
     eventName: T;
     on?: EventListener<T>;
     once?: EventListener<T>;
-    off?: EventListener<T>;
 }
 
 export const TypedEvent = <T extends EventName>(event: IBotEvent<T>) => event;


### PR DESCRIPTION
Off is an alias for `removeListenter`, so this is pointless.