### PR TITLE
Implement Suggestion Threads

### DIFF
--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -38,7 +38,7 @@ export const command: IBotCommand = {
         await message.react("✅");
         await message.react("❌");
         await message.startThread({
-            name: interaction.options.getString("title"),
+            name: interaction.options.getString("title", true),
             autoArchiveDuration: "MAX"
         });
 

--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -28,8 +28,7 @@ export const command: IBotCommand = {
             .setColor("ORANGE")
             .setTitle(
                 `${interaction.options.getString("title")} - ${
-                    interaction.member?.user.username
-                }#${interaction.member?.user.discriminator}`
+                    interaction.member?.user.tag}`
             )
             .setDescription(interaction.options.getString("description", true));
 
@@ -37,7 +36,11 @@ export const command: IBotCommand = {
             embeds: [suggestionEmbed],
         });
         await message.react("✅");
-        message.react("❌");
+        await message.react("❌");
+        await message.startThread({
+            name: interaction.options.getString("title"),
+            autoArchiveDuration: "MAX"
+        });
 
         const successMessageEmbed = new MessageEmbed()
             .setColor("GREEN")


### PR DESCRIPTION
### What?
Added automatic thread creation to suggestion command.
Replaced unnecessary interpolation of `user.username` and `user.discriminator` by using the [`user.tag`](https://discord.js.org/#/docs/discord.js/stable/class/User?scrollTo=tag) property instead.

### Why?
Threads allow for easy discussion about suggestions without needing to clutter up the rest of the server with new channels.

### What else needs doing?
_This still needs live testing - working on that now._