### PR TITLE
Better types

### DIFF
--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -10,7 +10,7 @@ import { TypedEvent } from "../types";
 
 export default TypedEvent({
     eventName: "guildMemberAdd",
-    on: async (client: Bot, member: GuildMember | PartialGuildMember) => {
+    run: async (client: Bot, member: GuildMember | PartialGuildMember) => {
         if (member.partial) return;
         member.roles.add(config.memberRoleId);
 

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -10,7 +10,7 @@ import { TypedEvent } from "../types";
 
 export default TypedEvent({
     eventName: "guildMemberRemove",
-    on: async (client: Bot, member: GuildMember | PartialGuildMember) => {
+    run: async (client: Bot, member: GuildMember | PartialGuildMember) => {
         if (member.partial) return;
         memberRemoveEvent(member, client);
     },

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -11,7 +11,7 @@ import { TypedEvent } from "../types";
 
 export default TypedEvent({
     eventName: "guildMemberUpdate",
-    on: async (
+    run: async (
         client: Bot,
         oldMember: GuildMember | PartialGuildMember,
         newMember: GuildMember | PartialGuildMember

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -4,7 +4,7 @@ import { TypedEvent } from "../types";
 
 export default TypedEvent({
     eventName: "interactionCreate",
-    on: async (client: Bot, interaction: Interaction) => {
+    run: async (client: Bot, interaction: Interaction) => {
         if (!interaction.isCommand() || !interaction.inCachedGuild()) return;
 
         const command = client.commands.get(interaction.commandName);

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -8,7 +8,7 @@ const forbiddenPhrases: string[] = ["discord.gg"];
 
 export default TypedEvent({
     eventName: "messageCreate",
-    on: async (client: Bot, message: Message) => {
+    run: async (client: Bot, message: Message) => {
         if (message.author.bot) return;
         const foundPhrase = forbiddenPhrases.find((phrase) =>
             message.content.includes(phrase)

--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -6,7 +6,7 @@ import utils from "../utils";
 
 export default TypedEvent({
     eventName: "messageDelete",
-    on: (client: Bot, message: Message | PartialMessage) => {
+    run: (client: Bot, message: Message | PartialMessage) => {
         // Check if the message is partial
         if (message.partial) return;
 

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -10,7 +10,7 @@ import { getData } from "../utils";
 
 export default TypedEvent({
     eventName: "messageReactionAdd",
-    on: async (
+    run: async (
         _,
         reaction: MessageReaction | PartialMessageReaction,
         user: User | PartialUser

--- a/src/events/messageReactionRemove.ts
+++ b/src/events/messageReactionRemove.ts
@@ -10,7 +10,7 @@ import { getData } from "../utils";
 
 export default TypedEvent({
     eventName: "messageReactionRemove",
-    on: async (
+    run: async (
         _,
         reaction: MessageReaction | PartialMessageReaction,
         user: User | PartialUser

--- a/src/events/messageUpdate.ts
+++ b/src/events/messageUpdate.ts
@@ -6,7 +6,7 @@ import utils from "../utils";
 
 export default TypedEvent({
     eventName: "messageUpdate",
-    on: (
+    run: (
         client: Bot,
         oldMessage: Message | PartialMessage,
         newMessage: Message | PartialMessage

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -9,7 +9,8 @@ import { commandFiles } from "../files";
 
 export default TypedEvent({
     eventName: "ready",
-    once: async (client: Bot) => {
+    once: true,
+    run: async (client: Bot) => {
         client.logger.console.info(`Logged in as ${client.user?.tag}.`);
 
         const data = await getData();
@@ -32,7 +33,7 @@ export default TypedEvent({
             );
         }
 
-        const rest = new REST({ version: "9" }).setToken(config.token!);
+        const rest = new REST({ version: "9" }).setToken(config.token);
 
         rest.put(
             Routes.applicationGuildCommands(client.user.id, config.guildId),
@@ -54,7 +55,6 @@ export default TypedEvent({
             const emojis = [];
 
             for (const reactionKey in reactionMessage.reactions) {
-                //@ts-ignore
                 const reaction = reactionMessage.reactions[reactionKey];
                 reactionEmbed.description += `${reaction.emoji}: ${reactionKey}\n`;
                 emojis.push(reaction.emoji);

--- a/src/structures/Bot.ts
+++ b/src/structures/Bot.ts
@@ -27,18 +27,10 @@ export class Bot extends Client<true> {
                 continue;
             }
 
-            const listenerMethod = ["on", "once"];
-            for await (const method of listenerMethod) {
-                // I can't find a better way to do this, I am sorry
-                // @ts-expect-error
-                if (!event[method] || typeof event[method] != "function")
-                    continue;
-                // @ts-expect-error
-                this[method](event.eventName, (...args: any) =>
-                    // @ts-expect-error
-                    event[method]!(this, ...args)
-                );
-            }
+            if (event.once)
+                this.once(event.eventName, event.run.bind(null, this));
+            else this.on(event.eventName, event.run.bind(null, this));
+
             this.logger.console.debug(`Registered event ${event.eventName}`);
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,8 +30,8 @@ export type EventListener<T extends EventName> = (
 
 export interface IBotEvent<T extends EventName> {
     eventName: T;
-    on?: EventListener<T>;
-    once?: EventListener<T>;
+    once?: boolean;
+    run: EventListener<T>;
 }
 
 export const TypedEvent = <T extends EventName>(event: IBotEvent<T>) => event;


### PR DESCRIPTION
This pr makes it so that events use the run method instead of having separate on and once methods, and specifying once with the once: true property. This is so that I could remove all the type skipping behavior (yes there were 3 in that one section), which caused a previous bug in another pr.

I also removed an unnecessary //@ts-ignore in ready.ts. There weren't any ts errors there, but if there ever would be, they'd be suppressed which isn't good...

I've tested this locally and everything seems to work fine, the ready event fires fine, and slash commands work
Please tell me if you find any issues with it tho