### PR TITLE
Limit range function in order to prevent crashes

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { MessageEmbed } from "discord.js";
-import { evaluate } from "mathjs";
+import {create, all, range as oldRange, BigNumber} from 'mathjs';
 import { IBotCommand } from "../types";
 
 export const command: IBotCommand = {
@@ -14,20 +14,30 @@ export const command: IBotCommand = {
                 .setRequired(true)
         ),
     async execute(interaction) {
+        const math = create(all)
+        math.import({
+            range: (start: number | BigNumber, end: number | BigNumber, step: number | BigNumber, includeEnd?: boolean) : math.Matrix => {
+                if (math.compare(math.subtract(end,start), 99999) === 1) throw new Error("Range size can't be bigger than 99999")
+                if (step !== undefined) return oldRange(start,end,step)
+                else if (includeEnd !== undefined) return oldRange(start,end,includeEnd)
+                else if ((step !== undefined) && (includeEnd !== undefined)) return oldRange(start,end,step,includeEnd)
+                else return oldRange(start,end)
+            }
+        },  { override: true })
         const calc = interaction.options.getString("calculation", true);
-        interaction.deferReply({ ephemeral: true })
+        await interaction.deferReply({ephemeral: true})
 
         try {
-            const result = evaluate(calc);
+            const result = math.evaluate(calc);
             const successEmbed = new MessageEmbed()
                 .setColor("GREEN")
                 .setDescription(`Input: \`${calc}\`\nResult: \`${result}\``);
-            interaction.editReply({ embeds: [successEmbed], ephemeral: true });
+            await interaction.editReply({embeds: [successEmbed]});
         } catch (err) {
             const errorEmbed = new MessageEmbed()
                 .setColor("RED")
                 .setDescription(`Input: \`${calc}\`\nError: \`${err}\``);
-            interaction.editReply({ embeds: [errorEmbed], ephemeral: true });
+            await interaction.editReply({embeds: [errorEmbed]});
         }
     },
 };

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -15,18 +15,19 @@ export const command: IBotCommand = {
         ),
     async execute(interaction) {
         const calc = interaction.options.getString("calculation", true);
+        interaction.deferReply({ ephemeral: true })
 
         try {
             const result = evaluate(calc);
             const successEmbed = new MessageEmbed()
                 .setColor("GREEN")
                 .setDescription(`Input: \`${calc}\`\nResult: \`${result}\``);
-            interaction.reply({ embeds: [successEmbed], ephemeral: true });
+            interaction.editReply({ embeds: [successEmbed], ephemeral: true });
         } catch (err) {
             const errorEmbed = new MessageEmbed()
                 .setColor("RED")
                 .setDescription(`Input: \`${calc}\`\nError: \`${err}\``);
-            interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+            interaction.editReply({ embeds: [errorEmbed], ephemeral: true });
         }
     },
 };


### PR DESCRIPTION
This PR Changes behavior of the range() function of math.js in order to prevent crashes while dealing with large ranges but by doing that removes some functionality from the range() function like string arguments being no longer accepted. This PR also defers the interaction response to make actions that take more than 3secs possible
Fixes #42 