### PR TITLE
🎨 Prettier enhancements and Pre commit formatting with Husky

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx pretty-quick --staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+*-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,6 @@
-{ "tabWidth": 4 }
+{
+    "tabWidth": 4,
+    "importOrder": ["^[./]"],
+    "importOrderSeparation": true,
+    "importOrderSortSpecifiers": true
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Boolean
 
 ## About
-A bot for Conaticus' [Discord server](https://discord.com/invite/aDAsjZVzaH). A document of the development process has been made here: https://www.youtube.com/watch?v=xq2jR3_msmk. 
 
+A bot for Conaticus' [Discord server](https://discord.com/invite/aDAsjZVzaH). A document of the development process has been made here: https://www.youtube.com/watch?v=xq2jR3_msmk.
 
 If you like cool coding projects like this, subscribe to me at https://www.youtube.com/channel/UCRLHJ-7b4pjDpBBHAUXEvjQ
 
@@ -12,26 +12,25 @@ If you like cool coding projects like this, subscribe to me at https://www.youtu
 
 #### Installation
 
-- Clone/Fork the repository
-- Run `cd boolean`
-- Run `npm i`
+-   Clone/Fork the repository
+-   Run `cd boolean`
+-   Run `npm i`
 
 #### Setting up the .env
-
 
 In order to setup the bot, you must create a `.env` in the parent directory as you can see in the example, [.env.example](https://github.com/conaticus/boolean/blob/master/.env.example).
 
 In this file you must declare the bot's `TOKEN` - this is the token from the [Discord Developer Portal](https://discord.com/developers/applications).
 
 Syntax:
+
 ```env
 TOKEN="your bot's TOKEN"
 ```
 
-
 This will automatically be ignored from the [.gitignore](https://github.com/conaticus/boolean/blob/master/.gitignore). So don't worry about this data being public.
 
-#### 
+####
 
 #### Running the bot
 
@@ -42,6 +41,7 @@ Due to many of the values being hardcoded, in order to run your instance you wil
 ### Other Information
 
 #### Embed Colours
+
 General: `"ORANGE"` \
 Success: `"GREEN"` \
 Error: `"RED"`
@@ -57,26 +57,29 @@ Data is currently stored in the [data.json](https://github.com/conaticus/boolean
 # Config
 
 #### Set
- To specify something in the config find the `config` object in the `config.ts` file, after specify something like `"NAME": <VALUE>`.
+
+To specify something in the config find the `config` object in the `config.ts` file, after specify something like `"NAME": <VALUE>`.
 
 #### Get
- To read from it, require `config` then read the value specified by doing `config.<VALUE TO READ>`.
+
+To read from it, require `config` then read the value specified by doing `config.<VALUE TO READ>`.
 
 # Logging
 
 #### Console levels and their refrences
- - Fatal   :   `logger.console.fatal("")`
- - Error   :   `logger.console.error("")`
- - Warn    :   `logger.console.warn("")`
- - Info    :   `logger.console.info("")`
- - Debug   :   `logger.console.debug("")`
- - Trace   :   `logger.console.trace("")`
- - Silent  :   `logger.console.silent("")`
+
+-   Fatal : `logger.console.fatal("")`
+-   Error : `logger.console.error("")`
+-   Warn : `logger.console.warn("")`
+-   Info : `logger.console.info("")`
+-   Debug : `logger.console.debug("")`
+-   Trace : `logger.console.trace("")`
+-   Silent : `logger.console.silent("")`
 
 #### Channel logging
- -Embed    : `logger.channel(<EMBED>, <CHANNEL>)`
+
+-Embed : `logger.channel(<EMBED>, <CHANNEL>)`
 
 ## Contributing
 
 Look at [CONTRIBUTING.md](https://github.com/conaticus/boolean/blob/master/CONTRIBUTING.md) to find out how you can help contribute to the development of this bot.
-

--- a/data.json
+++ b/data.json
@@ -1,1 +1,6 @@
-{"reactionMessages":{"Languages":"960896318736334868","Pings":"960896319910719528"}} 
+{
+    "reactionMessages": {
+        "Languages": "960896318736334868",
+        "Pings": "960896319910719528"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "build": "tsc",
         "start": "node .",
         "check": "tsc -w --noEmit",
-        "format": "prettier --write ."
+        "format": "prettier --write .",
+        "prepare": "husky install"
     },
     "keywords": [],
     "author": "",
@@ -27,7 +28,9 @@
         "@trivago/prettier-plugin-sort-imports": "^3.2.0",
         "@types/node": "^17.0.24",
         "dotenv": "^16.0.0",
+        "husky": "^7.0.0",
         "prettier": "^2.6.2",
+        "pretty-quick": "^3.1.3",
         "ts-node-dev": "^1.1.8"
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@trivago/prettier-plugin-sort-imports": "^3.2.0",
         "@types/node": "^17.0.24",
         "dotenv": "^16.0.0",
-        "husky": "^7.0.0",
+        "husky": "^7.0.4",
         "prettier": "^2.6.2",
         "pretty-quick": "^3.1.3",
         "ts-node-dev": "^1.1.8"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "dev": "ts-node-dev --respawn ./src/index.ts",
         "build": "tsc",
         "start": "node .",
-        "check": "tsc -w --noEmit"
+        "check": "tsc -w --noEmit",
+        "format": "prettier --write ."
     },
     "keywords": [],
     "author": "",
@@ -23,8 +24,10 @@
         "pino-pretty": "^7.6.1"
     },
     "devDependencies": {
+        "@trivago/prettier-plugin-sort-imports": "^3.2.0",
         "@types/node": "^17.0.24",
         "dotenv": "^16.0.0",
+        "prettier": "^2.6.2",
         "ts-node-dev": "^1.1.8"
     }
 }

--- a/src/commands/announce.ts
+++ b/src/commands/announce.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { MessageEmbed, TextChannel } from "discord.js";
+
 import config from "../config";
 import { IBotCommand } from "../types";
 import utils from "../utils";

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { MessageEmbed } from "discord.js";
+
 import { IBotCommand } from "../types";
 
 export const command: IBotCommand = {

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -1,6 +1,7 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { MessageEmbed } from "discord.js";
-import {create, all, range as oldRange, BigNumber} from 'mathjs';
+import { BigNumber, all, create, range as oldRange } from "mathjs";
+
 import { IBotCommand } from "../types";
 
 export const command: IBotCommand = {
@@ -14,30 +15,43 @@ export const command: IBotCommand = {
                 .setRequired(true)
         ),
     async execute(interaction) {
-        const math = create(all)
-        math.import({
-            range: (start: number | BigNumber, end: number | BigNumber, step: number | BigNumber, includeEnd?: boolean) : math.Matrix => {
-                if (math.compare(math.subtract(end,start), 99999) === 1) throw new Error("Range size can't be bigger than 99999")
-                if (step !== undefined) return oldRange(start,end,step)
-                else if (includeEnd !== undefined) return oldRange(start,end,includeEnd)
-                else if ((step !== undefined) && (includeEnd !== undefined)) return oldRange(start,end,step,includeEnd)
-                else return oldRange(start,end)
-            }
-        },  { override: true })
+        const math = create(all);
+        math.import(
+            {
+                range: (
+                    start: number | BigNumber,
+                    end: number | BigNumber,
+                    step: number | BigNumber,
+                    includeEnd?: boolean
+                ): math.Matrix => {
+                    if (math.compare(math.subtract(end, start), 99999) === 1)
+                        throw new Error(
+                            "Range size can't be bigger than 99999"
+                        );
+                    if (step !== undefined) return oldRange(start, end, step);
+                    else if (includeEnd !== undefined)
+                        return oldRange(start, end, includeEnd);
+                    else if (step !== undefined && includeEnd !== undefined)
+                        return oldRange(start, end, step, includeEnd);
+                    else return oldRange(start, end);
+                },
+            },
+            { override: true }
+        );
         const calc = interaction.options.getString("calculation", true);
-        await interaction.deferReply({ephemeral: true})
+        await interaction.deferReply({ ephemeral: true });
 
         try {
             const result = math.evaluate(calc);
             const successEmbed = new MessageEmbed()
                 .setColor("GREEN")
                 .setDescription(`Input: \`${calc}\`\nResult: \`${result}\``);
-            await interaction.editReply({embeds: [successEmbed]});
+            await interaction.editReply({ embeds: [successEmbed] });
         } catch (err) {
             const errorEmbed = new MessageEmbed()
                 .setColor("RED")
                 .setDescription(`Input: \`${calc}\`\nError: \`${err}\``);
-            await interaction.editReply({embeds: [errorEmbed]});
+            await interaction.editReply({ embeds: [errorEmbed] });
         }
     },
 };

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { CommandInteraction } from "discord.js";
+
 import { IBotCommand } from "../types";
 
 const timeout = (seconds: number): Promise<void> => {

--- a/src/commands/quiz.ts
+++ b/src/commands/quiz.ts
@@ -6,6 +6,7 @@ import {
     TextChannel,
     User,
 } from "discord.js";
+
 import { IBotCommand } from "../types";
 
 interface IQuestion {

--- a/src/commands/repeat.ts
+++ b/src/commands/repeat.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { MessageEmbed } from "discord.js";
+
 import { IBotCommand } from "../types";
 
 export const command: IBotCommand = {

--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { MessageEmbed, TextChannel } from "discord.js";
+
 import config from "../config";
 import { IBotCommand } from "../types";
 
@@ -28,7 +29,8 @@ export const command: IBotCommand = {
             .setColor("ORANGE")
             .setTitle(
                 `${interaction.options.getString("title")} - ${
-                    interaction.member?.user.tag}`
+                    interaction.member?.user.tag
+                }`
             )
             .setDescription(interaction.options.getString("description", true));
 
@@ -39,7 +41,7 @@ export const command: IBotCommand = {
         await message.react("❌");
         await message.startThread({
             name: interaction.options.getString("title", true),
-            autoArchiveDuration: "MAX"
+            autoArchiveDuration: "MAX",
         });
 
         const successMessageEmbed = new MessageEmbed()

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -4,6 +4,7 @@ import {
     PartialGuildMember,
     TextChannel,
 } from "discord.js";
+
 import config from "../config";
 import { Bot } from "../structures/Bot";
 import { TypedEvent } from "../types";

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -4,6 +4,7 @@ import {
     PartialGuildMember,
     TextChannel,
 } from "discord.js";
+
 import config from "../config";
 import { Bot } from "../structures/Bot";
 import { TypedEvent } from "../types";

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -5,6 +5,7 @@ import {
     TextChannel,
     User,
 } from "discord.js";
+
 import config from "../config";
 import { Bot } from "../structures/Bot";
 import { TypedEvent } from "../types";

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,4 +1,5 @@
 import { Interaction, MessageEmbed } from "discord.js";
+
 import { Bot } from "../structures/Bot";
 import { TypedEvent } from "../types";
 

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,4 +1,5 @@
 import { Message, MessageEmbed, TextChannel } from "discord.js";
+
 import config from "../config";
 import { Bot } from "../structures/Bot";
 import { TypedEvent } from "../types";

--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -1,4 +1,5 @@
 import { Message, MessageEmbed, PartialMessage, TextChannel } from "discord.js";
+
 import config from "../config";
 import { Bot } from "../structures/Bot";
 import { TypedEvent } from "../types";

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -4,6 +4,7 @@ import {
     PartialUser,
     User,
 } from "discord.js";
+
 import config from "../config";
 import { TypedEvent } from "../types";
 import { getData } from "../utils";

--- a/src/events/messageReactionRemove.ts
+++ b/src/events/messageReactionRemove.ts
@@ -4,6 +4,7 @@ import {
     PartialUser,
     User,
 } from "discord.js";
+
 import config from "../config";
 import { TypedEvent } from "../types";
 import { getData } from "../utils";

--- a/src/events/messageUpdate.ts
+++ b/src/events/messageUpdate.ts
@@ -1,4 +1,5 @@
 import { Message, MessageEmbed, PartialMessage, TextChannel } from "discord.js";
+
 import config from "../config";
 import { Bot } from "../structures/Bot";
 import { TypedEvent } from "../types";

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,11 +1,12 @@
 import { REST } from "@discordjs/rest";
 import { Routes } from "discord-api-types/rest/v9";
 import { Collection, MessageEmbed, TextChannel } from "discord.js";
+
 import config from "../config";
+import { commandFiles } from "../files";
 import { Bot } from "../structures/Bot";
 import { IBotCommand, TypedEvent } from "../types";
 import { getData, writeData } from "../utils";
-import { commandFiles } from "../files";
 
 export default TypedEvent({
     eventName: "ready",

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,4 +1,5 @@
 import path from "path";
+
 const filehound = require("filehound"); // sad
 
 function generator() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-import "dotenv/config";
 import { Intents } from "discord.js";
+import "dotenv/config";
+
 import { Bot } from "./structures/Bot";
 
 export const bot = new Bot({

--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -1,31 +1,29 @@
-import {
-    Channel,
-    MessageEmbed,
-    TextChannel,
-} from "discord.js";
+import { Channel, MessageEmbed, TextChannel } from "discord.js";
 
-const pino = require('pino')
+const pino = require("pino");
 /**
  * @class Logger
  */
 export default class Logger {
     Wconsole: any;
-	/**
-	 * @prop {Array} transports
-	 * @prop {Boolean} exitOnError
-	 */
-	constructor(options?: any) {
-
-		this.Wconsole = new pino({transport: {target: 'pino-pretty'}, ...options});
-	}
+    /**
+     * @prop {Array} transports
+     * @prop {Boolean} exitOnError
+     */
+    constructor(options?: any) {
+        this.Wconsole = new pino({
+            transport: { target: "pino-pretty" },
+            ...options,
+        });
+    }
 
     get console(): any {
-        return this.Wconsole
+        return this.Wconsole;
     }
 
     channel(embed: MessageEmbed, channel: Channel) {
         if (channel instanceof TextChannel) {
-            channel.send({embeds: [embed]});
+            channel.send({ embeds: [embed] });
         }
     }
 }

--- a/src/structures/Bot.ts
+++ b/src/structures/Bot.ts
@@ -8,6 +8,7 @@ import { IBotCommand, IBotEvent } from "../types";
 export class Bot extends Client<true> {
     commands = new Collection<string, IBotCommand>();
     logger = new Logger({ level: config.logLevel });
+
     constructor(options: ClientOptions) {
         super(options);
     }

--- a/src/structures/Bot.ts
+++ b/src/structures/Bot.ts
@@ -1,8 +1,9 @@
 import { Client, ClientOptions, Collection } from "discord.js";
-import { IBotCommand, IBotEvent } from "../types";
+
+import config from "../config";
 import { eventFiles } from "../files";
 import Logger from "../logger/Logger";
-import config from "../config";
+import { IBotCommand, IBotEvent } from "../types";
 
 export class Bot extends Client<true> {
     commands = new Collection<string, IBotCommand>();

--- a/src/structures/Bot.ts
+++ b/src/structures/Bot.ts
@@ -8,7 +8,6 @@ import { IBotCommand, IBotEvent } from "../types";
 export class Bot extends Client<true> {
     commands = new Collection<string, IBotCommand>();
     logger = new Logger({ level: config.logLevel });
-
     constructor(options: ClientOptions) {
         super(options);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import {
     CommandInteraction,
     PermissionResolvable,
 } from "discord.js";
+
 import { Bot } from "./structures/Bot";
 
 export interface IBotCommand {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,12 @@
-import { Collection, CommandInteraction, MessageAttachment, MessageEmbed } from "discord.js";
-import { IDataObject } from "./types";
+import {
+    Collection,
+    CommandInteraction,
+    MessageAttachment,
+    MessageEmbed,
+} from "discord.js";
 import fs from "fs/promises";
+
+import { IDataObject } from "./types";
 
 export const getData = async (): Promise<IDataObject> =>
     JSON.parse(await fs.readFile("./data.json", "utf8"));


### PR DESCRIPTION
Below listed changes are made:

- Added a `format` command to format all the code with Prettier
- Ignored unneeded files for formatting
- Sorting import statements with a [prettier plugin](https://www.npmjs.com/package/@trivago/prettier-plugin-sort-imports) when the file is formatted
- Added `husky` to format the staged files with Prettier before commit

Let me know if any changes are required