### PR TITLE
Some unbreaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "keywords": [],
     "author": "",
-    "license": "ISC",
+    "license": "MIT",
     "dependencies": {
         "@discordjs/builders": "^0.12.0",
         "@discordjs/rest": "^0.3.0",

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -11,6 +11,7 @@ export const command: IBotCommand = {
             option
                 .setName("amount")
                 .setDescription("Amount of messages to delete")
+                .setMinValue(1)
                 .setRequired(true)
         ),
     requiredPerms: ["MANAGE_MESSAGES"],

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -17,7 +17,7 @@ export const command: IBotCommand = {
     requiredPerms: ["MANAGE_MESSAGES"],
     async execute(interaction) {
         await interaction.deferReply({ ephemeral: true });
-        
+
         const deleted = await interaction.channel!.bulkDelete(
             interaction.options.getNumber("amount", true),
             true

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -15,6 +15,8 @@ export const command: IBotCommand = {
         ),
     requiredPerms: ["MANAGE_MESSAGES"],
     async execute(interaction) {
+        await interaction.deferReply({ ephemeral: true });
+        
         const deleted = await interaction.channel!.bulkDelete(
             interaction.options.getNumber("amount", true),
             true
@@ -23,6 +25,6 @@ export const command: IBotCommand = {
         const successEmbed = new MessageEmbed()
             .setColor("GREEN")
             .setDescription(`Deleted \`${deleted.size}\` messages.`);
-        await interaction.reply({ embeds: [successEmbed], ephemeral: true });
+        await interaction.editReply({ embeds: [successEmbed] });
     },
 };

--- a/src/commands/quiz.ts
+++ b/src/commands/quiz.ts
@@ -109,7 +109,7 @@ const constructQuestionOptions = async (
     if (optionMessage.content === "next") return options;
 
     options.push(optionMessage.content);
-    return await constructQuestionOptions(
+    return constructQuestionOptions(
         user,
         channel,
         questionNumber,
@@ -170,7 +170,7 @@ const constructQuestions = async (
         options: questionOptions,
         correctOptionIdx,
     });
-    return await constructQuestions(user, channel, questions);
+    return constructQuestions(user, channel, questions);
 };
 
 export const command: IBotCommand = {

--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -34,6 +34,8 @@ export const command: IBotCommand = {
             )
             .setDescription(interaction.options.getString("description", true));
 
+        await interaction.deferReply({ ephemeral: true });
+
         const message = await suggestionsChannel.send({
             embeds: [suggestionEmbed],
         });
@@ -50,6 +52,6 @@ export const command: IBotCommand = {
                 `Suggestion successfully created at <#${config.suggestionsChannelId}>`
             );
 
-        interaction.reply({ embeds: [successMessageEmbed], ephemeral: true });
+        interaction.editReply({ embeds: [successMessageEmbed] });
     },
 };

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -32,10 +32,16 @@ export default TypedEvent({
             await command.execute(interaction, client);
         } catch (e) {
             console.error(e);
-            await interaction.reply({
-                content: "There was an error while executing this command.",
-                ephemeral: true,
-            });
+            if (interaction.deferred || interaction.replied) {
+                await interaction.editReply({
+                    content: "There was an error while executing this command."
+                });
+            } else {
+                await interaction.reply({
+                    content: "There was an error while executing this command.",
+                    ephemeral: true,
+                });
+            }
         }
     },
 });

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -35,7 +35,9 @@ export default TypedEvent({
 
             const errorEmbed = new MessageEmbed()
                 .setColor("RED")
-                .setDescription("❌ **|** An error occurred while executing the command.");
+                .setDescription(
+                    "❌ An error occurred while executing the command."
+                );
 
             if (interaction.deferred || interaction.replied) {
                 await interaction.editReply({

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -32,13 +32,20 @@ export default TypedEvent({
             await command.execute(interaction, client);
         } catch (e) {
             console.error(e);
+
+            const errorEmbed = new MessageEmbed()
+                .setColor("RED")
+                .setDescription("❌ **|** An error occurred while executing the command.");
+
             if (interaction.deferred || interaction.replied) {
                 await interaction.editReply({
-                    content: "There was an error while executing this command."
+                    content: " ",
+                    embeds: [errorEmbed],
                 });
             } else {
                 await interaction.reply({
-                    content: "There was an error while executing this command.",
+                    content: " ",
+                    embeds: [errorEmbed],
                     ephemeral: true,
                 });
             }

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -26,7 +26,7 @@ export default TypedEvent({
             if (id !== reaction.message.id) return;
 
             Object.values(rm.reactions).forEach((msgReaction) => {
-                if (msgReaction.emoji.includes(reaction.emoji.id! ?? reaction.emoji.name!))
+                if (msgReaction.emoji.includes(reaction.emoji.id! ?? reaction.emoji.name))
                     member.roles.add(msgReaction.roleId);
             });
         });

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -26,7 +26,7 @@ export default TypedEvent({
             if (id !== reaction.message.id) return;
 
             Object.values(rm.reactions).forEach((msgReaction) => {
-                if (msgReaction.emoji.includes(reaction.emoji.id!))
+                if (msgReaction.emoji.includes(reaction.emoji.id! ?? reaction.emoji.name!))
                     member.roles.add(msgReaction.roleId);
             });
         });

--- a/src/events/messageReactionRemove.ts
+++ b/src/events/messageReactionRemove.ts
@@ -26,7 +26,7 @@ export default TypedEvent({
             if (id !== reaction.message.id) return;
 
             Object.values(rm.reactions).forEach((msgReaction) => {
-                if (msgReaction.emoji.includes(reaction.emoji.id!))
+                if (msgReaction.emoji.includes(reaction.emoji.id! ?? reaction.emoji.name!))
                     member.roles.remove(msgReaction.roleId);
             });
         });

--- a/src/events/messageReactionRemove.ts
+++ b/src/events/messageReactionRemove.ts
@@ -26,7 +26,7 @@ export default TypedEvent({
             if (id !== reaction.message.id) return;
 
             Object.values(rm.reactions).forEach((msgReaction) => {
-                if (msgReaction.emoji.includes(reaction.emoji.id! ?? reaction.emoji.name!))
+                if (msgReaction.emoji.includes(reaction.emoji.id! ?? reaction.emoji.name))
                     member.roles.remove(msgReaction.roleId);
             });
         });


### PR DESCRIPTION
## Changes

* [`Defer replies`](dda71e56646928959f5a05f2c79dc679f9e0df72) I think it's better to defer the reply first if the bot awaits before it sends its reply. This allows the bot 15 minutes to complete its tasks before responding, because waiting for the task before responding may invalidate the interaction token if the tasks took more than 3 seconds
* [`Redundant awaits`](d0b0621a3b48bcc6cc46e4d73429b6fd0e219690) A Promise is always wrapped around an async function's return value. As a result, the use of return await is redundant.
* [`match license`](ef70e0271fba2b2c4ba8fea683093ccadf7281ff) Match repo license to package.json
* [`edit reply if a deffered/replied interaction caught an error`](33f1c0a47ba0057f49c88d002768a8a36507dcf8)
* [`An error occurs to /clear when the value is 0`](5bd6e0dde3b4327ff49050ec3034677e6380712f)
* [`Caught error message as an embed`](357d3088c926d4242f3a40d874f55bbf4fc23e6d) I think it's better if the error message is sent as an embed
* [`format`](739fbd8f9e0162444f1c89c25a80438decceba1a) `npm run format` the changes
* [`check if the emoji matches the name if it has no id`](41b55f6358af33afd5047e8de6a666457bb43d6b) Use emoji name if there's no emoji id when using discord's default emojis a problem from #59  