### PR TITLE
Ignore .idea and .vscode folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /dist
 .env
 package-lock.json
+.vscode
+.idea


### PR DESCRIPTION
For a cleaner project, we should ignore `.idea` and `.vscode` folder. Kinda annoying to see unversioned files in my JetBrains IDE

![image](https://user-images.githubusercontent.com/49687450/164980363-83c00d70-3683-4526-8dd1-90a21666ef3c.png)