### PR TITLE
Remove Prettier config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /node_modules
 /dist
 .env
-package-lock.json
-.vscode
 .idea
+.prettierrc.json
+.prettierignore
+.vscode
+package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-node_modules
-*-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,0 @@
-{
-    "tabWidth": 4,
-    "importOrder": ["^[./]"],
-    "importOrderSeparation": true,
-    "importOrderSortSpecifiers": true
-}

--- a/package.json
+++ b/package.json
@@ -25,13 +25,11 @@
         "pino-pretty": "^7.6.1"
     },
     "devDependencies": {
-        "@trivago/prettier-plugin-sort-imports": "^3.2.0",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.24",
         "dotenv": "^16.0.0",
         "husky": "^7.0.4",
         "jest": "^27.5.1",
-        "prettier": "^2.6.2",
         "pretty-quick": "^3.1.3",
         "ts-jest": "^27.1.4",
         "ts-node-dev": "^1.1.8"


### PR DESCRIPTION
Since linters, formatters, etc. are really specific to the person writing the code, I find that it's better to keep their configuration out of the repository root.