### PR TITLE
Remove CLIENT_ID in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
 TOKEN=your bot token
-CLIENT_ID=your bot client id


### PR DESCRIPTION
Remove CLIENT_ID in .env.example: not used
already get the client id from the client object