### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.github
+.husky
+__tests__
+.editorconfig
+.env.example
+.eslintignore
+.eslintrc.json
+.gitignore
+.prettierignore
+.prettierrc.json
+CONTRIBUTING.md
+jest.config.ts
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:16-alpine AS base
+
+WORKDIR /opt/app
+COPY package.json /opt/app
+
+RUN npm install
+
+FROM base AS build
+
+COPY . /opt/app
+RUN npm run build
+
+FROM base as production
+
+USER node
+
+COPY --from=build /opt/app/package.json /opt/app/package.json
+COPY --from=build /opt/app/node_modules /opt/app/node_modules
+
+COPY --from=build /opt/app/dist /opt/app/dist
+COPY --from=build /opt/app/.env /opt/app/.env
+COPY --from=build /opt/app/data.json /opt/app/data.json
+
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A bot for Conaticus' [Discord server](https://discord.com/invite/aDAsjZVzaH). A 
 
 -   Clone/Fork the repository
 -   Run `cd boolean`
--   Run `npm i`
 
 #### Setting up the .env
 
@@ -28,9 +27,16 @@ TOKEN="your bot's TOKEN"
 
 This will automatically be ignored from the [.gitignore](https://github.com/conaticus/boolean/blob/master/.gitignore). So don't worry about this data being public.
 
-####
+#### Docker
+
+For Docker users, simply run
+
+-   `docker build --tag boolean:latest .`
+-   `docker run boolean:latest`
 
 #### Running the bot
+
+-   Run `npm i`
 
 In order to start the bot, you must run `npm run dev` to run the TypeScript developer environment. Don't worry about the other `package.json` scripts, they are for production.
 


### PR DESCRIPTION
Adding a Dockerfile allows users to deploy this bot to their servers quickly.

note: This PR isn't building because (blame: ebf3e17edb8991a3bf749811ab7db5c51d2687ec) of line 21 in this snippet...

https://github.com/conaticus/boolean/blob/ebf3e17edb8991a3bf749811ab7db5c51d2687ec/src/events/guildMemberAdd.ts#L17-L23


Let me know your thoughts and if we need to write the README differently.

