### PR TITLE
Add a current activity to the ready event.

### DIFF
--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -14,6 +14,11 @@ export default TypedEvent({
     run: async (client: Bot) => {
         client.logger.console.info(`Logged in as ${client.user?.tag}.`);
 
+        client.user.setActivity({
+            name: "/help",
+            type: "WATCHING",
+        });
+
         const data = await getData();
 
         const commandArr: object[] = [];


### PR DESCRIPTION
Adding a current activity to the bot will help some users figure out how to use the bot. Change the text if you wish, but telling the user the main help command is a great idea to set as the activity since that is where many users check if they can't figure out how to use the bot at all.