### PR TITLE
Parsed mentions to names in suggestions + Improved invite detection system

### DIFF
--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { MessageEmbed, TextChannel } from "discord.js";
+import { MessageEmbed, TextChannel, Util } from "discord.js";
 
 import { config_ as config } from "../configs/config-handler";
 import { IBotCommand } from "../types/types";
@@ -28,13 +28,14 @@ const command: IBotCommand = {
             config.suggestionsChannelId
         ) as TextChannel;
 
+        const title = Util.cleanContent(
+            interaction.options.getString("title", true),
+            interaction.channel!
+        );
+
         const suggestionEmbed = new MessageEmbed()
             .setColor("ORANGE")
-            .setTitle(
-                `${interaction.options.getString("title")} - ${
-                    interaction.member?.user.tag
-                }`
-            )
+            .setTitle(`${title} - ${interaction.member?.user.tag}`)
             .setDescription(interaction.options.getString("description", true));
 
         await interaction.deferReply({ ephemeral: true });
@@ -45,7 +46,7 @@ const command: IBotCommand = {
         await message.react("✅");
         await message.react("❌");
         const thread = await message.startThread({
-            name: interaction.options.getString("title", true),
+            name: title,
             autoArchiveDuration: "MAX",
         });
         await thread.members.add(interaction.user);

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,4 +1,4 @@
-import { Message, MessageEmbed, TextChannel } from "discord.js";
+import { Invite, Message, MessageEmbed, TextChannel } from "discord.js";
 import { stringSimilarity } from "string-similarity-js";
 import { weirdToNormalChars } from "weird-to-normal-chars";
 
@@ -7,13 +7,7 @@ import { Bot } from "../structures/Bot";
 import { TypedEvent } from "../types/types";
 import utils from "./../utils";
 
-const forbiddenPhrases: string[] = [
-    "discord.gg",
-    "porn",
-    "orange youtube",
-    "faggot",
-    "kys",
-];
+const forbiddenPhrases: string[] = ["porn", "orange youtube", "faggot", "kys"];
 
 export default TypedEvent({
     eventName: "messageCreate",
@@ -32,6 +26,15 @@ export default TypedEvent({
                 )
         );
         if (foundPhrase) return message.delete();
+
+        const inviteURLs = message.content.match(Invite.INVITES_PATTERN) ?? [];
+        for (const inviteURL of inviteURLs) {
+            const invite = await client
+                .fetchInvite(inviteURL)
+                .catch(() => null);
+            if (invite && invite.guild?.id !== config.guildId)
+                return await message.delete();
+        }
 
         if (
             message.mentions.users.size > 5 &&


### PR DESCRIPTION
* parsed mentions to names in suggestions names and suggestions threads names
* removed `discord.gg` from the words filter that use string similarity detection
* added a more accurate invite url detector and checked if it's not an invite from the bots working server before deleting it