### PR TITLE
Changes /deny required permissions + Added sanctions appeals with modals

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -37,6 +37,7 @@ const specChannels: APIApplicationCommandOptionChoice<string>[] = [
     "warnings",
     "logs",
     "roles",
+    "appeals",
 ].map((v) => ({
     name: v,
     value: v,

--- a/src/commands/deny.ts
+++ b/src/commands/deny.ts
@@ -59,7 +59,7 @@ class Deny extends BotCommand {
                         })
                 )
                 .toJSON(),
-            { requiredPerms: ["ADMINISTRATOR"] }
+            { requiredPerms: ["MANAGE_ROLES"] }
         );
     }
 

--- a/src/commands/verbal.ts
+++ b/src/commands/verbal.ts
@@ -1,5 +1,10 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { CommandInteraction, MessageEmbed, TextChannel } from "discord.js";
+import {
+    CommandInteraction,
+    MessageEmbed,
+    TextChannel,
+    MessageActionRow,
+} from "discord.js";
 
 import { getSpecialChannel } from "../database";
 import { BotCommand } from "../structures";
@@ -40,24 +45,110 @@ class Verbal extends BotCommand {
             throw new Error("There is not a warnings channel yet.");
         }
         const warnChannel = optWarnings as TextChannel;
-        const member = interaction.options.getMember("user");
+        const member = interaction.options.getMember("user", true);
+        const reason = interaction.options.getString("reason", true);
 
         const warnEmbed = new MessageEmbed().setColor("RED").setDescription(`
                 User: <@${member?.user.id}>
-                Reason: \`${interaction.options.getString("reason", true)}\`
+                Reason: \`${reason}\`
                 Moderator: <@${interaction.member.user.id}>
             `);
 
         const dmEmbed = new MessageEmbed()
             .setColor("RED")
             .setTitle("You have recieved a warning").setDescription(`
-                Reason: ${interaction.options.getString("reason", true)}
+                Reason: ${reason}
                 Moderator: <@${interaction.member.user.id}>
 
-                If you believe this warning is unjustified, please contact Conaticus.
+                If you believe this warning is unjustified, appeal using the button below.
             `);
-
-        await member?.send({ embeds: [dmEmbed] });
+        const appealButton = {
+            type: "BUTTON",
+            label: "Appeal warning",
+            style: "PRIMARY",
+            customId: "appeal_warning",
+            emoji: "📜",
+            disabled: false,
+        };
+        const components = [
+            {
+                type: "ACTION_ROW",
+                components: [appealButton],
+                // NOTE(HordLawk): why the fuck did ts make me do this
+            } as unknown as MessageActionRow,
+        ];
+        const dm = await member
+            ?.send({ embeds: [dmEmbed], components })
+            .catch(() => null);
+        if (dm) {
+            const collector = dm.createMessageComponentCollector({
+                componentType: "BUTTON",
+                time: 600_000,
+            });
+            collector.on("collect", async (i) => {
+                await i.showModal({
+                    customId: `appeal_${i.id}`,
+                    title: "Appeal warning",
+                    components: [
+                        {
+                            type: "ACTION_ROW",
+                            components: [
+                                {
+                                    type: "TEXT_INPUT",
+                                    label: "Elaborate",
+                                    placeholder:
+                                        "Explain why you think your warning was unjustified",
+                                    style: "PARAGRAPH",
+                                    customId: "content",
+                                    required: true,
+                                },
+                            ],
+                        },
+                    ],
+                });
+                const int = await i
+                    .awaitModalSubmit({
+                        filter: (inte) => inte.customId === `appeal_${i.id}`,
+                        time: 600_000,
+                    })
+                    .catch(() => null);
+                if (!int) {
+                    await i.followUp({
+                        content: "Modal timed out",
+                        ephemeral: true,
+                    });
+                    return;
+                }
+                const appealEmbed = new MessageEmbed()
+                    .setColor(0x2f3136)
+                    .setAuthor({
+                        name: `${member.user.username} appealed their warning`,
+                        iconURL: member.user.displayAvatarURL({
+                            dynamic: true,
+                        }),
+                    })
+                    .setDescription(int.fields.getTextInputValue("content"))
+                    .setTimestamp()
+                    .addField("Offender", member.toString(), true)
+                    .addField("Moderator", interaction.user.toString(), true)
+                    .addField("Warning reason", reason);
+                const optAppeal = await getSpecialChannel(
+                    interaction.guild.id,
+                    "appeals"
+                );
+                if (!optAppeal)
+                    throw new Error("There is not an appeals channel yet.");
+                const appealsChannel = optAppeal as TextChannel;
+                await appealsChannel.send({ embeds: [appealEmbed] });
+                appealButton.disabled = true;
+                await int.update({ components });
+            });
+            collector.on("end", async () => {
+                if (!dm.editable) return;
+                appealButton.disabled = true;
+                await dm.edit({ components });
+            });
+        }
 
         await warnChannel.send({
             embeds: [warnEmbed],

--- a/src/commands/verbal.ts
+++ b/src/commands/verbal.ts
@@ -64,6 +64,7 @@ class Verbal extends BotCommand {
                 If you believe this warning is unjustified, appeal using the button below.
             `);
         const appealButton = new MessageButton()
+            .setLabel("Appeal warning")
             .setEmoji("📜")
             .setCustomId("appeal_warning")
             .setStyle("PRIMARY");
@@ -98,9 +99,6 @@ class Verbal extends BotCommand {
             time: 600_000,
         });
         collector.once("end", async () => {
-            if (!dm.editable) {
-                return;
-            }
             appealButton.setDisabled(true);
             await dm.edit({ components });
         });

--- a/src/database/channels.ts
+++ b/src/database/channels.ts
@@ -20,7 +20,8 @@ export type SpecialChannel =
     | "welcomes"
     | "warnings"
     | "logs"
-    | "roles";
+    | "roles"
+    | "appeals";
 
 /**
  * Utility function of getSpecialChannel

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -7,6 +7,7 @@ import {
     PartialGuildMember,
     User,
     TextChannel,
+    MessageButton,
 } from "discord.js";
 
 import { Bot } from "../structures";
@@ -179,21 +180,14 @@ Duration: ${durationFormatted} (<t:${Math.floor(
 
 **If you believe this time out is unjustified, appeal using the button below.**
                 `);
-            const appealButton = {
-                type: "BUTTON",
-                label: "Appeal time out",
-                style: "PRIMARY",
-                customId: "appeal_timeout",
-                emoji: "📜",
-                disabled: false,
-            };
-            const components = [
-                {
-                    type: "ACTION_ROW",
-                    components: [appealButton],
-                    // NOTE(HordLawk): why the fuck did ts make me do this
-                } as unknown as MessageActionRow,
-            ];
+            const appealButton = new MessageButton()
+                .setLabel("Appeal time out")
+                .setStyle("PRIMARY")
+                .setCustomId("appeal_timeout")
+                .setEmoji("📜");
+            const appealRow = new MessageActionRow();
+            appealRow.addComponents(appealButton);
+            const components = [appealRow];
             const dm = await newMember
                 .send({ embeds: [dmEmbed], components })
                 .catch(() => null);
@@ -236,6 +230,7 @@ Duration: ${durationFormatted} (<t:${Math.floor(
                     });
                     return;
                 }
+                collector.stop();
                 const appealEmbed = new MessageEmbed()
                     .setColor(0x2f3136)
                     .setAuthor({
@@ -257,11 +252,11 @@ Duration: ${durationFormatted} (<t:${Math.floor(
                     throw new Error("There is not an appeals channel yet.");
                 const appealsChannel = optAppeal as TextChannel;
                 await appealsChannel.send({ embeds: [appealEmbed] });
-                appealButton.disabled = true;
+                appealButton.setDisabled(true);
                 await int.update({ components });
             });
             collector.on("end", async () => {
-                appealButton.disabled = true;
+                appealButton.setDisabled(true);
                 await dm.edit({ components });
             });
         }


### PR DESCRIPTION
* Defined `/deny` required permissions as `MANAGE_ROLES` (the permission moderator managers have) which resolves #131 
* Added a button to warnings and time outs dms which shows a modal to the offender where they can submit an appeal that will be sent directly to the moderator managers and admins which closes #132 