### PR TITLE
Remove deleted channel option

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -34,7 +34,6 @@ const specChannels: APIApplicationCommandOptionChoice<string>[] = [
     "information",
     "suggestions",
     "welcomes",
-    "warnings",
     "logs",
     "roles",
     "appeals",


### PR DESCRIPTION
Removed the "warnings" channel option from the config command as it is no longer supported.